### PR TITLE
Change stop after match behavior for use with parserLLM

### DIFF
--- a/rellm/rellm.py
+++ b/rellm/rellm.py
@@ -47,8 +47,9 @@ def complete_re(prompt:str, pattern: regex.Pattern | List[regex.Pattern], tokeni
 
         if stop_after_match:
             for p in pattern:
-                if p.fullmatch(partial_completion):
-                    return partial_completion
+                m = p.match(partial_completion)
+                if m and m.start() == 0:
+                    return m[0]
         gen_tokens += 1
 
     return partial_completion


### PR DESCRIPTION
First off, thanks so much for your work on this package! So useful.

When trying to use `rellm` with `parserllm` (https://github.com/r2d4/parserllm), I kept getting `UnexpectedCharacter` exceptions from Lark. I tracked these down to the stop after match behavior in `rellm`. When using the example JSON CFG, I would have something generated like:

```
valid next token: [regex.Regex('\\{', flags=regex.V0), regex.Regex('\\[', flags=regex.V0)]
step=0 completion={
valid next token: [regex.Regex('".*?(?<!\\\\)(\\\\\\\\)*?"', flags=regex.V0), regex.Regex('\\}', flags=regex.V0)]
step=0 completion="
step=1 completion="positive
step=2 completion="positive":
step=3 completion="positive":true
step=4 completion="positive":true,
step=5 completion="positive":true,"
```

Note, the step 2 completion added in `":` and thus wasn't a full match, but I would actually want a stop after match here, because `"positive"` would represent the next token in the JSON CFG parsing. This behavior eventually causes the `next_lex` method to raise an exception, because the step 5 completion was a full match (despite being an incomplete match to a JSON pattern). 

To fix this, I changed the `fullmatch` method in `rellm` to `match` along with a check to make sure the match starts at index 0. There might be a better way to do this, but it worked for me!