### PR TITLE
Fix generating partially valid tokens

### DIFF
--- a/rellm/re_token_filter.py
+++ b/rellm/re_token_filter.py
@@ -16,7 +16,7 @@ class ReTokenFilter:
 
     def is_valid_token(self, token_id: int, partial_completion: str, patterns: List[regex.Pattern]) -> bool:
         decoded_token = self.decoded_tokens_cache[token_id]
-        return any(pattern.fullmatch(partial_completion + decoded_token) for pattern in patterns)
+        return any(pattern.fullmatch(partial_completion + decoded_token, partial=True) for pattern in patterns)
 
     def filter_tokens(self, partial_completion: str, patterns: Union[regex.Pattern, List[regex.Pattern]]) -> Set[int]:
         if isinstance(patterns, regex.Pattern):

--- a/rellm/re_token_filter.py
+++ b/rellm/re_token_filter.py
@@ -16,7 +16,7 @@ class ReTokenFilter:
 
     def is_valid_token(self, token_id: int, partial_completion: str, patterns: List[regex.Pattern]) -> bool:
         decoded_token = self.decoded_tokens_cache[token_id]
-        return any(pattern.fullmatch(partial_completion + decoded_token, partial=True) for pattern in patterns)
+        return any(pattern.fullmatch(partial_completion + decoded_token) for pattern in patterns)
 
     def filter_tokens(self, partial_completion: str, patterns: Union[regex.Pattern, List[regex.Pattern]]) -> Set[int]:
         if isinstance(patterns, regex.Pattern):

--- a/rellm/rellm.py
+++ b/rellm/rellm.py
@@ -40,16 +40,22 @@ def complete_re(prompt:str, pattern: regex.Pattern | List[regex.Pattern], tokeni
         )
         new_token_ids = output_ids[0, prompt_length:]
         output_text = tokenizer.decode(new_token_ids, skip_special_tokens=True)
-        partial_completion += output_text
-        prompt_plus_completion = prompt_plus_completion + output_text
+
+        for output_char in output_text:
+            partial_completion += output_char
+            prompt_plus_completion = prompt_plus_completion + output_char
+
+            if stop_after_match:
+                for p in pattern:
+                    m = p.match(partial_completion)
+                    if m and m.start() == 0:
+                        if debug:
+                            print("step={} completion={}".format(gen_tokens, partial_completion))
+                        return m[0]
+
         if debug:
             print("step={} completion={}".format(gen_tokens, partial_completion))
 
-        if stop_after_match:
-            for p in pattern:
-                m = p.match(partial_completion)
-                if m and m.start() == 0:
-                    return m[0]
         gen_tokens += 1
 
     return partial_completion


### PR DESCRIPTION
Matching a regex partially can lead to generating a token which causes the whole generated sequence to be invalid, even if a substring of the token would result in a valid output.

The other option would be to tweak `complete_re` we run the `if stop_after_match:` block after every character of the token (rather than the full token text) to the output text, but that's less clean. Or is that needed to be able to generate some output sequences which can only occur by generating a larger invalid token and then pruning the output?

Edit: looks like we need the latter approach, see latest commit.