### PR TITLE
Trying to be a bit more greedy with the matches

### DIFF
--- a/rellm/rellm.py
+++ b/rellm/rellm.py
@@ -1,4 +1,3 @@
-
 from typing import List
 
 import regex
@@ -40,6 +39,7 @@ def complete_re(prompt:str, pattern: regex.Pattern | List[regex.Pattern], tokeni
         )
         new_token_ids = output_ids[0, prompt_length:]
         output_text = tokenizer.decode(new_token_ids, skip_special_tokens=True)
+        previous_partial_completion = partial_completion
         partial_completion += output_text
         prompt_plus_completion = prompt_plus_completion + output_text
         if debug:
@@ -48,8 +48,12 @@ def complete_re(prompt:str, pattern: regex.Pattern | List[regex.Pattern], tokeni
         if stop_after_match:
             for p in pattern:
                 m = p.match(partial_completion)
-                if m and m.start() == 0:
-                    return m[0]
+                if m:
+                    if m.start() == 0 and m.end() < (len(partial_completion) - 5):
+                        return m[0]
+                    if previous_partial_completion == partial_completion:
+                        return m[0]
+
         gen_tokens += 1
 
     return partial_completion


### PR DESCRIPTION
This is a hacky fix of mine for an issue I was having with matching numbers. I don't think it's a particularly great soln, open to other ideas - but putting there here for thought

When matching numbers I found this would always just match on the first digit. Say for example you are trying to produce a decimal number that may or may not have a decimal point (in my case it was the regex produced by lark for signed number `/-?\d+(\.\d{1,2})?/`) and the LLM is "trying" to say 13.51, it would instantly return 1 (or 13, or w/e the valid token it chose was).

So I tried to make it generate tokens until the partial completion matched, but the match was shorter than the partial completion (i.e. stop on the first token that no longer matched).

This worked ok, but quickly ran into the issue with the LLM sometimes producing `13.`, stopping because it no longer matched, and returning `13`. However if it had kept going for a bit longer it would have became a valid match again with `13.51`. So I just arbitrarily allowed it to generate 5 more tokens to see if it came back around. I also stop generating if the model selects a token that evaluates to an empty string (likely a special token like eos)

Not sure what the best solution here is especially considering there may be multiple patterns. One thought I had was to check for a match using `pattern.match(partial_completion, partial=False)` and a full match using `pattern.fullmatch(partial_completion, partial=True)` and stopping when there is a match, but not a partially completed match on the full string, indicating any further token would never produce a match. There are a bunch of issues with never ending generation there - but again, food for thought.